### PR TITLE
Add "random" as order option

### DIFF
--- a/src/nova-base/lib/novaGallery.php
+++ b/src/nova-base/lib/novaGallery.php
@@ -132,17 +132,15 @@ class novaGallery {
     return $iTimestamp;
   }
 
-  protected function shuffle_assoc(&$array) {
+  protected function shuffle_assoc($array) {
         $keys = array_keys($array);
-
         shuffle($keys);
 
         foreach($keys as $key) {
             $new[$key] = $array[$key];
         }
-    
-        $array = $new;
-        return true;
+
+        return $new;
   }
   
   protected function order($list, $order){
@@ -154,7 +152,7 @@ class novaGallery {
         arsort($list);
         break;
       case 'random':
-        $this->shuffle_assoc($list);
+        $list = $this->shuffle_assoc($list);
         break;
       default:
         // order by name

--- a/src/nova-base/lib/novaGallery.php
+++ b/src/nova-base/lib/novaGallery.php
@@ -132,6 +132,19 @@ class novaGallery {
     return $iTimestamp;
   }
 
+  protected function shuffle_assoc(&$array) {
+        $keys = array_keys($array);
+
+        shuffle($keys);
+
+        foreach($keys as $key) {
+            $new[$key] = $array[$key];
+        }
+    
+        $array = $new;
+        return true;
+  }
+  
   protected function order($list, $order){
     switch ($order) {
       case 'oldest':
@@ -139,6 +152,9 @@ class novaGallery {
         break;
       case 'newest':
         arsort($list);
+        break;
+      case 'random':
+        $this->shuffle_assoc($list);
         break;
       default:
         // order by name


### PR DESCRIPTION
This PR adds a new order "random" for albums and images.

**Result**: If chosen "random" as order, the albums or images are listed randomly instead of a order, such as _oldest_ or _newest_.

**Reason**: Sometimes there is no particular order in albums (e.g. imagine collecting images from friends for your holiday gallery) and you just want to display the images in a random order to make that clear.

Please test before merging.