### PR TITLE
Add per-album description

### DIFF
--- a/src/nova-base/app/pages/album.php
+++ b/src/nova-base/app/pages/album.php
@@ -44,6 +44,12 @@ if($parentPage){
   $parentPage = 'album/'.$parentPage;
 }
 
+if(file_exists(IMAGES_DIR.'/'.$album.'/description.html')){
+  $description = file_get_contents(IMAGES_DIR.'/'.$album.'/description.html');
+} else {
+  $description = '';
+}
+Page::addData('description', $description);
 Page::addData('gallery', $gallery);
 Page::addData('order', $order);
 Page::addData('album', $album);
@@ -51,3 +57,5 @@ Page::addData('parentPage', $parentPage);
 
 
 Template::render('album');
+
+?>

--- a/src/nova-themes/novagallery-light/album.php
+++ b/src/nova-themes/novagallery-light/album.php
@@ -9,6 +9,9 @@
         <div class="col-12 mb-4"><a href="<?php echo Site::url().'/'.Page::data('parentPage'); ?>" class="text-muted link-back">&laquo; <?php L::p('Back'); ?></a></div>
       <?php endif; ?>
       <div class="container">
+        <?php if(!empty(Page::data('description'))): ?>
+          <?php echo Page::data('description');?>
+        <?php endif; ?>
         <!-- albums -->
         <?php if($gallery->hasAlbums()): ?>
         <div class="row px-2 mt-4">

--- a/src/nova-themes/novagallery/album.php
+++ b/src/nova-themes/novagallery/album.php
@@ -9,6 +9,9 @@
         <div class="col-12 mb-4"><a href="<?php echo Site::url().'/'.Page::data('parentPage'); ?>" class="text-muted link-back">&laquo; <?php L::p('Back'); ?></a></div>
       <?php endif; ?>
       <div class="container">
+        <?php if(!empty(Page::data('description'))): ?>
+          <?php echo Page::data('description');?>
+        <?php endif; ?>
         <!-- albums -->
         <?php if($gallery->hasAlbums()): ?>
         <div class="row px-2 mt-4">


### PR DESCRIPTION
Hello! 

I am testing this gallery out and it seems to be just what I want, it's very nice thank you! 

I have never written PHP before, so please bear with my naivete. I wanted to see if I could include some small information on an album basis; for example, if it's pictures related to a trip, write a few sentences about the trip and include an embed of the google maps trip, something like that. It's related to #17. 

It seemed to me easy to just have a `description.html` file in each album folder, and if it has content, then display that content. 

Not the most user-friendly, but writing a little bit of HTML isn't a huge ask nowadays I suppose. I tested that it works on my website. 

I suppose to make it more robust and easier for people maybe adding a markdown conversion process so that the user doesn't have to worry about syntax errors in the html, they would just supply a description.md file in each album. But I guess I also like the low-dependency approach used here.

Anyway, it works for my purposes but obviously I haven't spent a lot of time thinking about a general solution to the problem or any problems associated with how this has been written, so I'm mainly writing this in case it can be useful for another user to patch into their code, with no expectation that it should be merged.

Thanks for the discussion!