### PR TITLE
Add support for a separate cache directory

### DIFF
--- a/src/nova-base/app/router.php
+++ b/src/nova-base/app/router.php
@@ -8,7 +8,7 @@ Router::add('/', function() {
 
 
 // Gallery
-Router::add('/galleries/(.*)/cache/(.*)/(.*)', function($var1, $var2, $var3) {
+Router::add('/cache/(.*)/cache/(.*)/(.*)', function($var1, $var2, $var3) {
   require 'auth.php';
   $album = rawurldecode($var1);
   $size = rawurldecode($var2);

--- a/src/nova-base/init.php
+++ b/src/nova-base/init.php
@@ -37,11 +37,17 @@ $imagesDirName = Site::config('imagesDirName');
 if(is_null($imagesDirName)){
   $imagesDirName = 'galleries';
 }
+$cacheDirName = Site::config('cacheDirName');
+if(is_null($cacheDirName)){
+  $cacheDirName = 'cache';
+}
 
 define('BASE_PATH', Site::basePath());
 
 define('IMAGES_DIR', ROOT_DIR.'/'.$imagesDirName);
+define('CACHE_DIR', ROOT_DIR.'/'.$cacheDirName);
 define('IMAGES_URL', BASE_PATH.'/'.$imagesDirName);
+define('CACHE_URL', BASE_PATH.'/'.$cacheDirName);
 define('IMAGES_QUALITY', Site::config('imageQuality'));
 
 define('THEME_DIR', 'nova-themes/'.Site::theme());

--- a/src/nova-base/lib/Image.php
+++ b/src/nova-base/lib/Image.php
@@ -25,7 +25,7 @@ class Image {
     self::$filePath = IMAGES_DIR.'/'.$album;
     self::$original = self::$filePath.'/'.$image;
     self::$cache = $cache;
-    self::$cacheDirRoot = self::$filePath.'/cache';
+    self::$cacheDirRoot = CACHE_DIR.'/cache';
     self::$cacheDir = self::$cacheDirRoot.'/'.$size;
     self::$cacheFile = self::$cacheDir.'/'.$image;
 
@@ -80,7 +80,7 @@ class Image {
       }
     }
 
-    $url = IMAGES_URL.'/'.$album.'/cache/';
+    $url = CACHE_URL.'/'.$album.'/cache/';
 
     if($size){
       $url .= $size.'/';

--- a/src/nova-config/site.example.php
+++ b/src/nova-config/site.example.php
@@ -13,6 +13,7 @@
       2000
   ],
   "imagesDirName": "galleries",
+  "cacheDirName": "cache",
   "imageCache": 1,
   "imageSizeBig": 2000,
   "imageSizeThumb": "400x400",


### PR DESCRIPTION
Storing the cached images together with the original images has two issues

The first issue is when the application can read the directory structure containing the images, but cannot write to it.

The second issue is that there might be file name collisions; for example, I actually have a folder named cache in my picture folder structure.

Being able to store the cache file in a separate folder has also the advantage that it makes easier to delete the cache; just delete the cache folder.
There is no risk to delete an image by accident