### PR TITLE
Report error on cache creation

### DIFF
--- a/src/nova-base/lib/novaGallery.php
+++ b/src/nova-base/lib/novaGallery.php
@@ -234,7 +234,12 @@ class novaGallery {
   protected function writeCache($dir){
     $cacheDir =  $dir.'/'.$this->cacheDir;
     if(!file_exists($cacheDir)){
-      mkdir($cacheDir, 0777, true);
+      if(!mkdir($cacheDir, 0777, true)){
+        $current_error_reporting = error_reporting();
+        if ($current_error_reporting !== 0) {
+          echo "Unable to create directory ".$cacheDir;
+        }
+      }
     }
     $cacheFile = $cacheDir.'/'.$this->cacheFile;
     $content = ['images' => $this->images, 'albums' => $this->albums];


### PR DESCRIPTION
Does not seem to be fatal, enable error reporting with

error_reporting(E_ALL);
ini_set('display_errors', 'On');